### PR TITLE
Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,10 @@ Usage
 -----
 
 ```fish
-$ subl [file or path]
+$ subl [options] [file ...]        edit the given files
+$ subl [options] [directory ...]   open the given directories
+$ subl [options] -                 edit stdin
+$ subl --help                      get help :)
 ```
 
 License

--- a/subl.fish
+++ b/subl.fish
@@ -22,6 +22,7 @@ function subl -d "Open Sublime Text"
   else if test -x "/opt/sublime_text_3/sublime_text"
     "/opt/sublime_text_3/sublime_text" $argv
   else
-    echo "No Sublime Text installation found"
+    echo "No Sublime Text installation found" >&2
+    return 1
   end
 end

--- a/subl.fish
+++ b/subl.fish
@@ -5,6 +5,30 @@
 #
 
 function subl -d "Open Sublime Text"
+  set -l opts
+  set -l files
+  set -l projects
+
+  # we'll just ignore anything that looks like an option string...
+  for file in $argv
+    switch $file
+      case '-*'
+        set opts $opts $file
+
+      case '.*' '*'
+        set files $files $file
+    end
+  end
+
+  # if there's one (and only one) *.sublime-project file in the folder listed, open that instead.
+  if [ (count $files) -eq 1 ]
+    set projects (find $files[1] -name "*.sublime-project" -maxdepth 1 2> /dev/null)
+  end
+
+  if [ (count $projects) -eq 1 ]
+    set argv $opts $projects[1]
+  end
+
   if begin; which subl > /dev/null; and test -x (which subl); end
     command subl $argv
   else if test -d "/Applications/Sublime Text.app"

--- a/subl.fish
+++ b/subl.fish
@@ -1,5 +1,7 @@
 # SYNOPSIS
-#   subl [file]
+#   subl [options] [file ...]        edit the given files
+#   subl [options] [directory ...]   open the given directories
+#   subl [options]                   edit stdin
 #
 
 function subl -d "Open Sublime Text"

--- a/subl.fish
+++ b/subl.fish
@@ -5,7 +5,9 @@
 #
 
 function subl -d "Open Sublime Text"
-  if test -d "/Applications/Sublime Text.app"
+  if begin; which subl > /dev/null; and test -x (which subl); end
+    command subl $argv
+  else if test -d "/Applications/Sublime Text.app"
     "/Applications/Sublime Text.app/Contents/SharedSupport/bin/subl" $argv
   else if test -d "/Applications/Sublime Text 2.app"
     "/Applications/Sublime Text 2.app/Contents/SharedSupport/bin/subl" $argv


### PR DESCRIPTION
I've been using a `subl` plugin for quite a while (and a `subl` function before OMF was a thing, and a Bash script even before that). I figure it's about time to contribute that back so everyone can enjoy an awesomer `subl` experience :)
- Update the synopsis and README with more complete usage.
- Better error handling: use a return status and echo the error message to stderr if sublime is not found.
- Defer to the `subl` executable on the path if one exists.
- If exactly one directory is passed, e.g. `subl .`, and that directory contains exactly one `*.sublime-project` file, load that project rather than the directory. This is basically what `subl` should be doing, but it's not :)
